### PR TITLE
Feat: apple 회원가입 시 apple_refresh_token 발급 후 저장 로직 추가

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -52,6 +52,13 @@ jobs:
           echo ACCESS_TOKEN_SECRET=${{ secrets.ACCESS_TOKEN_SECRET }} >> .env
           echo REFRESH_TOKEN_SECRET=${{ secrets.REFRESH_TOKEN_SECRET }} >> .env
           cat .env
+
+      - name: Create apple .p8
+        run: |
+          cd src
+          touch ${{ secrets.APPLE_KEYFILE_PATH }}
+          echo "${{ secrets.APPLE_PRIVATE_KEY }}" > ${{ secrets.APPLE_KEYFILE_PATH }}
+
       # Initialize Node.js
       - name: Install Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 .env
+*/*.p8

--- a/prisma/migrations/20230131111627_add_apple_refresh_token/migration.sql
+++ b/prisma/migrations/20230131111627_add_apple_refresh_token/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "apple_refresh_token" VARCHAR;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   refreshToken String?  @map("refresh_token") @db.VarChar()
   kakaoId      BigInt?  @map("kakao_id") @db.BigInt()
   appleId      String?  @map("apple_id") @db.VarChar()
+  appleRefreshToken String? @map("apple_refresh_token") @db.VarChar()
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @default(now()) @map("updated_at")
   isDeleted    Boolean  @default(false) @map("is_deleted")

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -21,7 +21,6 @@ import {
   ApiBadRequestResponse,
 } from '@nestjs/swagger';
 import { RESPONSE_MESSAGE } from 'src/common/objects';
-import CustomException from 'src/exceptions/custom.exception';
 import { wrapSuccess } from 'src/utils/success';
 import validation from 'src/utils/validation';
 import { AuthService } from './auth.service';
@@ -85,10 +84,14 @@ export class AuthController {
 
     switch (socialType) {
       case 'kakao':
-        data = await this.authService.createKakaoUser(signinDto);
+        data = (await this.authService.createKakaoUser(
+          signinDto,
+        )) as ResponseSigninData;
         break;
       case 'apple':
-        data = await this.authService.createAppleUser(signinDto);
+        data = (await this.authService.createAppleUser(
+          signinDto,
+        )) as ResponseSigninData;
     }
 
     return wrapSuccess(
@@ -113,10 +116,10 @@ export class AuthController {
   async updateToken(@Req() req): Promise<ResponseTokenDto> {
     const { id, refreshToken } = req.user;
 
-    const data: ResponseTokenData = await this.authService.updateToken(
+    const data: ResponseTokenData = (await this.authService.updateToken(
       id,
       refreshToken,
-    );
+    )) as ResponseTokenData;
 
     return wrapSuccess(
       HttpStatus.OK,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -77,9 +77,26 @@ export class AuthController {
     description: 'Unauthorized - 소셜 로그인 토큰이 없거나 유효하지 않은 경우',
   })
   async signin(@Body() signinDto: SigninDto): Promise<ResponseSigninDto> {
-    const { socialType, kakaoAccessToken, idToken } = signinDto;
+    const { socialType, kakaoAccessToken, idToken, code } = signinDto;
 
-    if ((kakaoAccessToken && idToken) || (!kakaoAccessToken && !idToken)) {
+    if (
+      (kakaoAccessToken && idToken && code) ||
+      (!kakaoAccessToken && !idToken && !code)
+    ) {
+      throw new CustomException(
+        HttpStatus.BAD_REQUEST,
+        RESPONSE_MESSAGE.BAD_REQUEST,
+      );
+    }
+
+    if (socialType === 'apple' && (!idToken || !code)) {
+      throw new CustomException(
+        HttpStatus.BAD_REQUEST,
+        RESPONSE_MESSAGE.BAD_REQUEST,
+      );
+    }
+
+    if (socialType === 'kakao' && (!kakaoAccessToken || idToken || code)) {
       throw new CustomException(
         HttpStatus.BAD_REQUEST,
         RESPONSE_MESSAGE.BAD_REQUEST,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -23,6 +23,7 @@ import {
 import { RESPONSE_MESSAGE } from 'src/common/objects';
 import CustomException from 'src/exceptions/custom.exception';
 import { wrapSuccess } from 'src/utils/success';
+import validation from 'src/utils/validation';
 import { AuthService } from './auth.service';
 import { ResponseCallbackDto } from './dto/response-callback.dto';
 import {
@@ -77,32 +78,9 @@ export class AuthController {
     description: 'Unauthorized - 소셜 로그인 토큰이 없거나 유효하지 않은 경우',
   })
   async signin(@Body() signinDto: SigninDto): Promise<ResponseSigninDto> {
-    const { socialType, kakaoAccessToken, idToken, code } = signinDto;
+    await validation.validationSignin(signinDto);
 
-    if (
-      (kakaoAccessToken && idToken && code) ||
-      (!kakaoAccessToken && !idToken && !code)
-    ) {
-      throw new CustomException(
-        HttpStatus.BAD_REQUEST,
-        RESPONSE_MESSAGE.BAD_REQUEST,
-      );
-    }
-
-    if (socialType === 'apple' && (!idToken || !code)) {
-      throw new CustomException(
-        HttpStatus.BAD_REQUEST,
-        RESPONSE_MESSAGE.BAD_REQUEST,
-      );
-    }
-
-    if (socialType === 'kakao' && (!kakaoAccessToken || idToken || code)) {
-      throw new CustomException(
-        HttpStatus.BAD_REQUEST,
-        RESPONSE_MESSAGE.BAD_REQUEST,
-      );
-    }
-
+    const { socialType } = signinDto;
     let data: ResponseSigninData;
 
     switch (socialType) {

--- a/src/auth/dto/signin.dto.ts
+++ b/src/auth/dto/signin.dto.ts
@@ -12,4 +12,7 @@ export class SigninDto {
 
   @ApiPropertyOptional({ description: 'apple id token' })
   idToken?: string;
+
+  @ApiPropertyOptional({ description: 'apple authorization code' })
+  code?: string;
 }

--- a/src/auth/strategies/access-token.strategy.ts
+++ b/src/auth/strategies/access-token.strategy.ts
@@ -1,11 +1,11 @@
-import { HttpStatus, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { JwtPayload } from 'src/common/interfaces/jwt-payload.interface';
-import { RESPONSE_MESSAGE } from 'src/common/objects';
 import CustomException from 'src/exceptions/custom.exception';
 import { PrismaService } from 'src/prisma.service';
+import { notFound } from 'src/utils/error';
 
 @Injectable()
 export class AccessTokenStrategy extends PassportStrategy(Strategy, 'jwt') {
@@ -17,7 +17,7 @@ export class AccessTokenStrategy extends PassportStrategy(Strategy, 'jwt') {
     });
   }
 
-  async validate(payload: JwtPayload): Promise<JwtPayload> {
+  async validate(payload: JwtPayload): Promise<JwtPayload | CustomException> {
     const user = await this.prisma.user.findUnique({
       where: {
         id: payload.id,
@@ -26,10 +26,7 @@ export class AccessTokenStrategy extends PassportStrategy(Strategy, 'jwt') {
     });
 
     if (!user) {
-      throw new CustomException(
-        HttpStatus.NOT_FOUND,
-        RESPONSE_MESSAGE.NOT_FOUND,
-      );
+      return notFound();
     }
 
     return {

--- a/src/common/interfaces/apple-payload.interface.ts
+++ b/src/common/interfaces/apple-payload.interface.ts
@@ -24,3 +24,10 @@ export interface DecodedTokenPayload {
     sub: string;
   };
 }
+
+export interface RequestTokenPayload {
+  client_id: string;
+  client_secret: string;
+  code: string;
+  grant_type: 'authorization_code';
+}

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -8,4 +8,8 @@ export default () => ({
   kakaoRedirectUrl: process.env.KAKAO_REDIRECT_URL,
   accessTokenSecret: process.env.ACCESS_TOKEN_SECRET,
   refreshTokenSecret: process.env.REFRESH_TOKEN_SECRET,
+  appleClientId: process.env.APPLE_CLIENTID,
+  appleTeamId: process.env.APPLE_TEAMID,
+  appleKeyId: process.env.APPLE_KEYID,
+  appleKeyFilePath: process.env.APPLE_KEYFILE_PATH,
 });

--- a/src/exceptions/index.ts
+++ b/src/exceptions/index.ts
@@ -1,0 +1,4 @@
+import CustomException from './custom.exception';
+import { GlobalExceptionFilter } from './global.exception';
+
+export { CustomException, GlobalExceptionFilter };

--- a/src/maps/maps.controller.ts
+++ b/src/maps/maps.controller.ts
@@ -65,7 +65,10 @@ export class MapsController {
     @Query() { lat, long }: ReadSmokingAreasQuery,
   ): Promise<ResponseSmokingAreasDto> {
     const data: ResponseSmokingAreasData =
-      await this.mapService.getMapsByLatAndLong(lat, long);
+      (await this.mapService.getMapsByLatAndLong(
+        lat,
+        long,
+      )) as ResponseSmokingAreasData;
 
     return wrapSuccess(
       HttpStatus.OK,
@@ -109,11 +112,11 @@ export class MapsController {
     @Param() { id }: ReadSmokingAreaParam,
     @Query() { lat, long }: ReadSmokingAreaQuery,
   ): Promise<ResponseSmokingAreaDto> {
-    const data: ResponseSmokingAreaData = await this.mapService.getMapById(
+    const data: ResponseSmokingAreaData = (await this.mapService.getMapById(
       id,
       lat,
       long,
-    );
+    )) as ResponseSmokingAreaData;
     return wrapSuccess(
       HttpStatus.OK,
       RESPONSE_MESSAGE.READ_SMOKING_AREA_SUCCESS,

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -59,7 +59,10 @@ export class UsersController {
     @Param() { id }: ReadNicknameParams,
   ): Promise<ResponseNicknameDto> {
     const data: ResponseNicknameData =
-      await this.usersService.getNicknameByUserId(req.user?.id, id);
+      (await this.usersService.getNicknameByUserId(
+        req.user?.id,
+        id,
+      )) as ResponseNicknameData;
 
     return wrapSuccess(
       HttpStatus.OK,
@@ -86,11 +89,11 @@ export class UsersController {
     @Body() updateNicknameDto: UpdateNicknameDto,
   ): Promise<ResponseNicknameDto> {
     const data: ResponseNicknameData =
-      await this.usersService.updateNicknameByUserId(
+      (await this.usersService.updateNicknameByUserId(
         req.user?.id,
         id,
         updateNicknameDto,
-      );
+      )) as ResponseNicknameData;
 
     return wrapSuccess(
       HttpStatus.OK,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,8 +1,8 @@
-import { HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { User } from '@prisma/client';
-import { RESPONSE_MESSAGE } from 'src/common/objects';
 import CustomException from 'src/exceptions/custom.exception';
 import { PrismaService } from 'src/prisma.service';
+import { forbidden, internalServerError, notFound } from 'src/utils/error';
 import { ResponseNicknameData } from './dto/response-nickname.dto';
 import { UpdateNicknameDto } from './dto/update-nickname.dto';
 
@@ -12,20 +12,17 @@ export class UsersService {
 
   private readonly logger = new Logger(UsersService.name);
 
-  async createUser(newUser) {
+  async createUser(newUser): Promise<User | CustomException> {
     try {
       const user = await this.prisma.user.create({ data: newUser });
       return user;
     } catch (error) {
       this.logger.error({ error });
-      throw new CustomException(
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        RESPONSE_MESSAGE.INTERNAL_SERVER_ERROR,
-      );
+      return internalServerError();
     }
   }
 
-  async getUserById(id: number): Promise<User> {
+  async getUserById(id: number): Promise<User | CustomException> {
     try {
       const user = await this.prisma.user.findUnique({
         where: {
@@ -36,14 +33,11 @@ export class UsersService {
       return user;
     } catch (error) {
       this.logger.error({ error });
-      throw new CustomException(
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        RESPONSE_MESSAGE.INTERNAL_SERVER_ERROR,
-      );
+      return internalServerError();
     }
   }
 
-  async getUserByKaKaoId(kakaoId: number): Promise<User> {
+  async getUserByKaKaoId(kakaoId: number): Promise<User | CustomException> {
     try {
       const user = await this.prisma.user.findFirst({
         where: {
@@ -54,14 +48,11 @@ export class UsersService {
       return user;
     } catch (error) {
       this.logger.error({ error });
-      throw new CustomException(
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        RESPONSE_MESSAGE.INTERNAL_SERVER_ERROR,
-      );
+      return internalServerError();
     }
   }
 
-  async getUserByAppleId(appleId: string): Promise<User> {
+  async getUserByAppleId(appleId: string): Promise<User | CustomException> {
     try {
       const user = await this.prisma.user.findFirst({
         where: {
@@ -72,22 +63,16 @@ export class UsersService {
       return user;
     } catch (error) {
       this.logger.error({ error });
-      throw new CustomException(
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        RESPONSE_MESSAGE.INTERNAL_SERVER_ERROR,
-      );
+      return internalServerError();
     }
   }
 
   async getNicknameByUserId(
     userId: number,
     id: number,
-  ): Promise<ResponseNicknameData> {
+  ): Promise<ResponseNicknameData | CustomException> {
     if (userId !== id) {
-      throw new CustomException(
-        HttpStatus.FORBIDDEN,
-        RESPONSE_MESSAGE.FORBIDDEN,
-      );
+      return forbidden();
     }
 
     try {
@@ -104,14 +89,14 @@ export class UsersService {
       return user;
     } catch (error) {
       this.logger.error(error);
-      throw new CustomException(
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        RESPONSE_MESSAGE.INTERNAL_SERVER_ERROR,
-      );
+      return internalServerError();
     }
   }
 
-  async updateRefreshTokenByUserId(id: number, refreshToken: string) {
+  async updateRefreshTokenByUserId(
+    id: number,
+    refreshToken: string,
+  ): Promise<User | CustomException> {
     try {
       const updatedUser = await this.prisma.user.update({
         where: { id },
@@ -122,10 +107,7 @@ export class UsersService {
       return updatedUser;
     } catch (error) {
       this.logger.error(error);
-      throw new CustomException(
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        RESPONSE_MESSAGE.INTERNAL_SERVER_ERROR,
-      );
+      return internalServerError();
     }
   }
 
@@ -133,12 +115,9 @@ export class UsersService {
     userId: number,
     id: number,
     updateNicknameDto: UpdateNicknameDto,
-  ): Promise<ResponseNicknameData> {
+  ): Promise<ResponseNicknameData | CustomException> {
     if (userId !== id) {
-      throw new CustomException(
-        HttpStatus.FORBIDDEN,
-        RESPONSE_MESSAGE.FORBIDDEN,
-      );
+      return forbidden();
     }
 
     try {
@@ -149,10 +128,7 @@ export class UsersService {
         },
       });
       if (!updatedUser) {
-        throw new CustomException(
-          HttpStatus.NOT_FOUND,
-          RESPONSE_MESSAGE.NOT_FOUND,
-        );
+        return notFound();
       }
 
       return {
@@ -160,10 +136,7 @@ export class UsersService {
       };
     } catch (error) {
       this.logger.error({ error });
-      throw new CustomException(
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        RESPONSE_MESSAGE.INTERNAL_SERVER_ERROR,
-      );
+      return internalServerError();
     }
   }
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,25 @@
+import { HttpStatus } from '@nestjs/common';
+import { CustomException } from '../exceptions';
+import { RESPONSE_MESSAGE } from '../common/objects';
+
+export const internalServerError = () => {
+  return new CustomException(
+    HttpStatus.INTERNAL_SERVER_ERROR,
+    RESPONSE_MESSAGE.INTERNAL_SERVER_ERROR,
+  );
+};
+
+export const badRequest = () => {
+  return new CustomException(
+    HttpStatus.BAD_REQUEST,
+    RESPONSE_MESSAGE.BAD_REQUEST,
+  );
+};
+
+export const forbidden = () => {
+  return new CustomException(HttpStatus.FORBIDDEN, RESPONSE_MESSAGE.FORBIDDEN);
+};
+
+export const notFound = () => {
+  return new CustomException(HttpStatus.NOT_FOUND, RESPONSE_MESSAGE.NOT_FOUND);
+};

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -16,6 +16,13 @@ export const badRequest = () => {
   );
 };
 
+export const unauthorized = () => {
+  return new CustomException(
+    HttpStatus.UNAUTHORIZED,
+    RESPONSE_MESSAGE.UNAUTHORIZED,
+  );
+};
+
 export const forbidden = () => {
   return new CustomException(HttpStatus.FORBIDDEN, RESPONSE_MESSAGE.FORBIDDEN);
 };

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,31 @@
+import { SigninDto } from 'src/auth/dto/signin.dto';
+import { CustomException } from 'src/exceptions';
+import { badRequest } from './error';
+
+const validationSignin = async (
+  createSigninDto: SigninDto,
+): Promise<CustomException> => {
+  const { socialType, kakaoAccessToken, idToken, code } = createSigninDto;
+
+  if (!kakaoAccessToken && !idToken && !code) {
+    return badRequest();
+  }
+
+  if (kakaoAccessToken && idToken && code) {
+    return badRequest();
+  }
+
+  if (socialType === 'kakao' && !kakaoAccessToken) {
+    return badRequest();
+  }
+
+  if (socialType === 'apple') {
+    if ((idToken && !code) || (!idToken && code)) {
+      return badRequest();
+    }
+  }
+};
+
+export = {
+  validationSignin,
+};


### PR DESCRIPTION
## 📚 PR 요약 / Linked Issue
해당 PR에서 작업한 내용을 한 줄로 요약해주세요.   
- close #50 

추후 회원 탈퇴 시 `apple refresh_token` 으로 revoke 요청을 보내야 재가입시 문제되지 않습니다.
따라서 apple login 최초 회원 가입 시 apple 서버로 `refresh_token` 발급을 요청해 db 에 저장해두는 로직을 추가했습니다.

## 💡 변경 사항
디테일한 작업 내역을 적어주세요.
주의할 사항이 있다면 적어주세요.
변경사항 (모듈 설치 등)이 있다면 적어주세요.

- User table 내 `apple_refresh_token` 필드 추가 마이그레이션
- 최초 회원가입 시 애플 서버에서 `refresh_token` 발급 후 디비에 저장
- (작성 중) yml 파일 .p8 파일 생성 스크립트 추가해야함

## ✅ PR check list   
- [x] 커밋 컨벤션, 제목 등을 확인했나요?   
- [x] 알맞은 라벨을 달았나요?   
- [x] 셀프 코드리뷰를 작성했나요?   
