### PR TITLE
Feat: 선호 지도 설정 API

### DIFF
--- a/src/common/objects/responseMessages.ts
+++ b/src/common/objects/responseMessages.ts
@@ -21,6 +21,7 @@ export const RESPONSE_MESSAGE: {
   // user
   READ_NICKNAME_SUCCESS: '유저 닉네임 조회 성공',
   UPDATE_NICKNAME_SUCCESS: '유저 닉네임 수정 성공',
+  UPDATE_PREFERRED_MAP_SUCCESS: '유저 선호지도 수정 성공',
 
   // map
   READ_SMOKING_AREAS_SUCCESS: '흡연구역 전체 조회 성공',

--- a/src/users/dto/update-preferredMap.dto.ts
+++ b/src/users/dto/update-preferredMap.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class UpdatePreferredMapDto {
+  @ApiProperty({ description: '0 - 카카오 / 1 - 구글 / 2 - 네이버' })
+  @IsNumber()
+  @IsNotEmpty()
+  preferredMap: number;
+}
+
+export class UpdatePreferredMapParams {
+  @IsNumber()
+  @Type(() => Number)
+  readonly id: number;
+}

--- a/src/users/dto/update-preferredMap.dto.ts
+++ b/src/users/dto/update-preferredMap.dto.ts
@@ -6,7 +6,7 @@ export class UpdatePreferredMapDto {
   @ApiProperty({ description: '0 - 카카오 / 1 - 구글 / 2 - 네이버' })
   @IsNumber()
   @IsNotEmpty()
-  preferredMap: number;
+  preferredMap: 0 | 1 | 2;
 }
 
 export class UpdatePreferredMapParams {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -29,6 +29,11 @@ import {
   UpdateNicknameDto,
   UpdateNicknameParams,
 } from './dto/update-nickname.dto';
+import { ResponseSuccessDto } from 'src/common/dto/response-success.dto';
+import {
+  UpdatePreferredMapDto,
+  UpdatePreferredMapParams,
+} from './dto/update-preferredMap.dto';
 import { UsersService } from './users.service';
 
 @Controller('users')
@@ -96,6 +101,36 @@ export class UsersController {
       HttpStatus.OK,
       RESPONSE_MESSAGE.UPDATE_NICKNAME_SUCCESS,
       data,
+    );
+  }
+
+  @Patch(':id/preferred-map')
+  @ApiOperation({
+    summary: '유저  선호지도 설정 API',
+    description: '유저 선호지도 설정 / 수정',
+  })
+  @ApiParam({
+    type: Number,
+    name: 'id',
+    required: true,
+    description: 'user id',
+  })
+  @ApiOkResponse({ type: ResponseSuccessDto })
+  async updatePreferredMap(
+    @Req() req,
+    @Param() { id }: UpdatePreferredMapParams,
+    @Body() updatePreferredMapDto: UpdatePreferredMapDto,
+  ): Promise<ResponseSuccessDto> {
+    console.log('here');
+    console.log(id);
+    await this.usersService.updatePreferredMapByUserId(
+      req.user?.id,
+      id,
+      updatePreferredMapDto,
+    );
+    return wrapSuccess(
+      HttpStatus.OK,
+      RESPONSE_MESSAGE.UPDATE_PREFERRED_MAP_SUCCESS,
     );
   }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -121,8 +121,6 @@ export class UsersController {
     @Param() { id }: UpdatePreferredMapParams,
     @Body() updatePreferredMapDto: UpdatePreferredMapDto,
   ): Promise<ResponseSuccessDto> {
-    console.log('here');
-    console.log(id);
     await this.usersService.updatePreferredMapByUserId(
       req.user?.id,
       id,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -5,6 +5,7 @@ import CustomException from 'src/exceptions/custom.exception';
 import { PrismaService } from 'src/prisma.service';
 import { ResponseNicknameData } from './dto/response-nickname.dto';
 import { UpdateNicknameDto } from './dto/update-nickname.dto';
+import { UpdatePreferredMapDto } from './dto/update-preferredMap.dto';
 
 @Injectable()
 export class UsersService {
@@ -158,6 +159,47 @@ export class UsersService {
       return {
         nickname: updatedUser.nickname,
       };
+    } catch (error) {
+      this.logger.error({ error });
+      throw new CustomException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        RESPONSE_MESSAGE.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  async updatePreferredMapByUserId(
+    userId: number,
+    id: number,
+    updatePreferredMapDto: UpdatePreferredMapDto,
+  ): Promise<void> {
+    if (userId !== id) {
+      throw new CustomException(
+        HttpStatus.FORBIDDEN,
+        RESPONSE_MESSAGE.FORBIDDEN,
+      );
+    }
+
+    if (updatePreferredMapDto.preferredMap > 2) {
+      throw new CustomException(
+        HttpStatus.BAD_REQUEST,
+        RESPONSE_MESSAGE.BAD_REQUEST,
+      );
+    }
+
+    try {
+      const updatedUser = await this.prisma.user.update({
+        where: { id, isDeleted: false },
+        data: {
+          preferredMap: updatePreferredMapDto.preferredMap,
+        },
+      });
+      if (!updatedUser) {
+        throw new CustomException(
+          HttpStatus.NOT_FOUND,
+          RESPONSE_MESSAGE.NOT_FOUND,
+        );
+      }
     } catch (error) {
       this.logger.error({ error });
       throw new CustomException(

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -180,13 +180,6 @@ export class UsersService {
       );
     }
 
-    if (updatePreferredMapDto.preferredMap > 2) {
-      throw new CustomException(
-        HttpStatus.BAD_REQUEST,
-        RESPONSE_MESSAGE.BAD_REQUEST,
-      );
-    }
-
     try {
       const updatedUser = await this.prisma.user.update({
         where: { id, isDeleted: false },


### PR DESCRIPTION
## 📚 PR 요약 / Linked Issue
close #49 
선호지도 설정, 수정 API를 구현

## 💡 변경 사항
- update-preferredMap.dto 추가
- User Controller, Service 플로우 추가

## ✅ PR check list   
- [x] 커밋 컨벤션, 제목 등을 확인했나요?   
- [x] 알맞은 라벨을 달았나요?   
- [x] 셀프 코드리뷰를 작성했나요?   
