### PR TITLE
Fix: 유저 닉네임 수정 시 중복 검사 추가

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiConflictResponse,
   ApiForbiddenResponse,
   ApiInternalServerErrorResponse,
   ApiOkResponse,
@@ -88,17 +89,18 @@ export class UsersController {
     description: 'user id',
   })
   @ApiOkResponse({ type: ResponseNicknameDto })
+  @ApiConflictResponse({ description: '중복된 닉네임일 경우' })
   async updateNickname(
     @Req() req,
     @Param() { id }: UpdateNicknameParams,
     @Body() updateNicknameDto: UpdateNicknameDto,
   ): Promise<ResponseNicknameDto> {
     const data: ResponseNicknameData =
-      (await this.usersService.updateNicknameByUserId(
+      await this.usersService.updateNicknameByUserId(
         req.user?.id,
         id,
         updateNicknameDto,
-      )) as ResponseNicknameData;
+      );
 
     return wrapSuccess(
       HttpStatus.OK,

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -30,3 +30,7 @@ export const forbidden = () => {
 export const notFound = () => {
   return new CustomException(HttpStatus.NOT_FOUND, RESPONSE_MESSAGE.NOT_FOUND);
 };
+
+export const conflict = () => {
+  return new CustomException(HttpStatus.CONFLICT, RESPONSE_MESSAGE.DUPLICATED);
+};


### PR DESCRIPTION
## 📚 PR 요약 / Linked Issue
해당 PR에서 작업한 내용을 한 줄로 요약해주세요.   
- close #75 

## 💡 변경 사항
디테일한 작업 내역을 적어주세요.
주의할 사항이 있다면 적어주세요.
변경사항 (모듈 설치 등)이 있다면 적어주세요.

<img src="https://github.com/TeamFogFog/FogFog-Server/assets/20807197/2168172c-0a40-4113-bd56-607bb7cb68f7" width="320px" />

- 해당 뷰에 맞게 유저 닉네임 수정 시 닉네임 중복 검사를 추가했습니다.
- 중복 에러는 409 Conflict 로 반환합니다.
- 에러가 이상하게 반환되는 이유를 찾았습니다!! `return errorHandleFunc()` -> `throw errorHandleFunc()` 으로만 수정하면 됩니다
  이렇게 바꾸면 앞으로 타입단언 한 부분도 다 지워도 됩니다 ㅎㅎ... 제가 한번에 #56 이랑 해당 pr 머지 후 에러 핸들링이랑 타입단언 수정해둘게요

## ✅ PR check list   
- [x] 커밋 컨벤션, 제목 등을 확인했나요?   
- [x] 알맞은 라벨을 달았나요?   
- [x] 셀프 코드리뷰를 작성했나요?   
